### PR TITLE
Provide search results on search-result plugin mount event

### DIFF
--- a/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
@@ -42,12 +42,10 @@ export default class PluginForm extends React.Component {
       Webcore.emitSlotSignal(
           node,
           "result-selection-ready",
-          ResultsSelected.get()
-      );
-      Webcore.emitSlotSignal(
-          node,
-          "result",
-          SearchStore.get()
+          {
+            "selected": ResultsSelected.get(),
+            "search": SearchStore.get()
+          }
       );
     }
   }

--- a/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
+++ b/dicoogle/src/main/resources/webapp/js/components/plugin/pluginForm.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import * as PropTypes from "prop-types";
 import { ResultsSelected } from "../../stores/resultSelected";
+import { SearchStore } from "../../stores/searchStore";
 import Webcore from "dicoogle-webcore";
 
 export default class PluginForm extends React.Component {
@@ -39,9 +40,14 @@ export default class PluginForm extends React.Component {
       node.addEventListener("hide", this.handleHideSignal);
 
       Webcore.emitSlotSignal(
-        node,
-        "result-selection-ready",
-        ResultsSelected.get()
+          node,
+          "result-selection-ready",
+          ResultsSelected.get()
+      );
+      Webcore.emitSlotSignal(
+          node,
+          "result",
+          SearchStore.get()
       );
     }
   }

--- a/dicoogle/src/main/resources/webapp/js/stores/searchStore.js
+++ b/dicoogle/src/main/resources/webapp/js/stores/searchStore.js
@@ -92,6 +92,12 @@ const SearchStore = Reflux.createStore({
       data: this._contents,
       success: true
     });
+  },
+
+  get: function() {
+    return {
+      data: this._contents
+    };
   }
 });
 


### PR DESCRIPTION
The webapp does not provide the full search results on the `result-selection-ready` event.

This PR fixes this issue by providing both the search results and the search results that were selected via the UI, instead of only providing the selected entries.
